### PR TITLE
Performance improvement

### DIFF
--- a/NSError+JSErrorStackTrace.m
+++ b/NSError+JSErrorStackTrace.m
@@ -23,7 +23,7 @@ NSString *const JSErrorStackTraceKey = @"com.javisoto.errorstacktracekey";
 {
     NSArray *stacktrace = [self.userInfo objectForKey:JSErrorStackTraceKey];
     
-    const NSUInteger linesToRemoveInStackTrace = 1; // This init method
+    const NSUInteger linesToRemoveInStackTrace = 1; // the swizzled init method
     stacktrace = [stacktrace subarrayWithRange:NSMakeRange(linesToRemoveInStackTrace, stacktrace.count - linesToRemoveInStackTrace)];
     
     return stacktrace.description;


### PR DESCRIPTION
I'm seeing an issue in our app where JSErrorStackTrace occupies rather a lot of CPU time. According to Instruments, `+[NSThread callStackSymbols]` is implemented using a custom `NSArray` subclass whose objects are evaluated lazily. The existing code's pattern of creating a sub-array is the worst possible case for that setup, as time is immediately spent looking up symbols which clients may not care about.

Presented here is an easy adjustment to the code that avoids this performance hit, but does change what JSErrorStackTrace returns.

How much do you care about this Javier? A more extensive solution (but which retains the same outward behaviour of old) would be to have a custom `NSDictionary` subclass which fills in `JSErrorStackTraceKey` on-demand, rather than immediately.
